### PR TITLE
Simplify protocol names

### DIFF
--- a/Sources/ImageScene.swift
+++ b/Sources/ImageScene.swift
@@ -9,11 +9,11 @@
 import SceneKit
 import UIKit
 
-public protocol ImageSceneProtocol: class {
+public protocol ImageScene: class {
     var image: UIImage? { get set }
 }
 
-public final class MonoSphericalImageScene: MonoSphericalMediaScene, ImageSceneProtocol {
+public final class MonoSphericalImageScene: MonoSphericalMediaScene, ImageScene {
     public var image: UIImage? {
         didSet {
             mediaSphereNode.mediaContents = image
@@ -21,7 +21,7 @@ public final class MonoSphericalImageScene: MonoSphericalMediaScene, ImageSceneP
     }
 }
 
-public final class StereoSphericalImageScene: StereoSphericalMediaScene, ImageSceneProtocol {
+public final class StereoSphericalImageScene: StereoSphericalMediaScene, ImageScene {
     public var image: UIImage? {
         didSet {
             var leftImage: UIImage?

--- a/Sources/MediaSceneLoader+Image.swift
+++ b/Sources/MediaSceneLoader+Image.swift
@@ -14,7 +14,7 @@ import SceneKit
 
 extension MediaSceneLoader {
     public func load(_ image: UIImage, format: MediaFormat) {
-        let scene: ImageSceneProtocol
+        let scene: ImageScene
 
         switch format {
         case .mono:

--- a/Sources/MediaSceneLoader+Video.swift
+++ b/Sources/MediaSceneLoader+Video.swift
@@ -15,7 +15,7 @@ import AVFoundation
 
 extension MediaSceneLoader {
     public func load(_ player: AVPlayer, format: MediaFormat) {
-        let scene: VideoSceneProtocol
+        let scene: VideoScene
 
         switch format {
         case .mono:

--- a/Sources/VideoScene.swift
+++ b/Sources/VideoScene.swift
@@ -13,13 +13,13 @@
 import SceneKit
 import AVFoundation
 
-public protocol VideoSceneProtocol: class {
+public protocol VideoScene: class {
     var renderer: PlayerRenderer { get }
 
     init(renderer: PlayerRenderer)
 }
 
-extension VideoSceneProtocol {
+extension VideoScene {
     public var player: AVPlayer? {
         get {
             return renderer.player
@@ -48,7 +48,7 @@ extension VideoSceneProtocol {
     }
 }
 
-public final class MonoSphericalVideoScene: MonoSphericalMediaScene, VideoSceneProtocol {
+public final class MonoSphericalVideoScene: MonoSphericalMediaScene, VideoScene {
     private var playerTexture: MTLTexture? {
         didSet {
             mediaSphereNode.mediaContents = playerTexture
@@ -128,7 +128,7 @@ public final class MonoSphericalVideoScene: MonoSphericalMediaScene, VideoSceneP
     }
 }
 
-public final class StereoSphericalVideoScene: StereoSphericalMediaScene, VideoSceneProtocol {
+public final class StereoSphericalVideoScene: StereoSphericalMediaScene, VideoScene {
     private var playerTexture: MTLTexture?
 
     private var leftSphereTexture: MTLTexture? {


### PR DESCRIPTION
- `ImageSceneProtocol` → `ImageScene`
- `VideoSceneProtocol` → `VideoScene`

Because there is no name conflicts.