### PR TITLE
Reset rotation at next rendering frame

### DIFF
--- a/Examples/MonoImage/Sources/ViewController.swift
+++ b/Examples/MonoImage/Sources/ViewController.swift
@@ -39,8 +39,8 @@ final class ViewController: UIViewController {
         ]
         NSLayoutConstraint.activate(constraints)
 
-        // double tap to reset center
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.resetCenter))
+        // double tap to reset rotation
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/MonoImage/Sources/ViewController.swift
+++ b/Examples/MonoImage/Sources/ViewController.swift
@@ -26,7 +26,7 @@ final class ViewController: UIViewController {
         #else
         let panoramaView = PanoramaView(frame: view.bounds) // iOS Simulator
         #endif
-
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 

--- a/Examples/MonoVideo/Sources/ViewController.swift
+++ b/Examples/MonoVideo/Sources/ViewController.swift
@@ -45,8 +45,8 @@ final class ViewController: UIViewController {
         ]
         NSLayoutConstraint.activate(constraints)
 
-        // double tap to reset center
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.resetCenter))
+        // double tap to reset rotation
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/MonoVideo/Sources/ViewController.swift
+++ b/Examples/MonoVideo/Sources/ViewController.swift
@@ -33,6 +33,7 @@ final class ViewController: UIViewController {
 
     private func loadPanoramaView() {
         let panoramaView = PanoramaView(frame: view.bounds, device: device)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 

--- a/Examples/StereoImage/Sources/ViewController.swift
+++ b/Examples/StereoImage/Sources/ViewController.swift
@@ -22,6 +22,7 @@ final class ViewController: UIViewController {
 
     private func loadPanoramaView() {
         let panoramaView = PanoramaView(frame: view.bounds, device: device)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 

--- a/Examples/StereoImage/Sources/ViewController.swift
+++ b/Examples/StereoImage/Sources/ViewController.swift
@@ -34,8 +34,8 @@ final class ViewController: UIViewController {
         ]
         NSLayoutConstraint.activate(constraints)
 
-        // double tap to reset center
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.resetCenter))
+        // double tap to reset rotation
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/StereoVideo/Sources/ViewController.swift
+++ b/Examples/StereoVideo/Sources/ViewController.swift
@@ -45,8 +45,8 @@ final class ViewController: UIViewController {
         ]
         NSLayoutConstraint.activate(constraints)
 
-        // double tap to reset center
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.resetCenter))
+        // double tap to reset rotation
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/StereoVideo/Sources/ViewController.swift
+++ b/Examples/StereoVideo/Sources/ViewController.swift
@@ -33,6 +33,7 @@ final class ViewController: UIViewController {
 
     private func loadPanoramaView() {
         let panoramaView = PanoramaView(frame: view.bounds, device: device)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 

--- a/MetalScope.xcodeproj/project.pbxproj
+++ b/MetalScope.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BF1452E11E320BEF0042598E /* MediaSceneLoader+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1452E01E320BEF0042598E /* MediaSceneLoader+Image.swift */; };
 		BF1452E31E320C210042598E /* MediaSceneLoader+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1452E21E320C210042598E /* MediaSceneLoader+Video.swift */; };
 		BF1453061E321CE30042598E /* CategoryBitMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1453051E321CE30042598E /* CategoryBitMask.swift */; };
+		BF46F09A1EADDEDA00F5CB58 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF46F0991EADDEDA00F5CB58 /* Deprecations+Removals.swift */; };
 		BF603F551E41B57600A28013 /* OrientationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF603F541E41B57600A28013 /* OrientationIndicator.swift */; };
 		BF9B15B41E44B47F004CC8CE /* RenderLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9B15B31E44B47F004CC8CE /* RenderLoop.swift */; };
 		BF9B15B61E44B4B1004CC8CE /* KeyValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9B15B51E44B4B1004CC8CE /* KeyValueObserver.swift */; };
@@ -50,6 +51,7 @@
 		BF1452E01E320BEF0042598E /* MediaSceneLoader+Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "MediaSceneLoader+Image.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BF1452E21E320C210042598E /* MediaSceneLoader+Video.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "MediaSceneLoader+Video.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BF1453051E321CE30042598E /* CategoryBitMask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CategoryBitMask.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		BF46F0991EADDEDA00F5CB58 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = "<group>"; };
 		BF603F541E41B57600A28013 /* OrientationIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrientationIndicator.swift; sourceTree = "<group>"; };
 		BF9B15B31E44B47F004CC8CE /* RenderLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderLoop.swift; sourceTree = "<group>"; };
 		BF9B15B51E44B4B1004CC8CE /* KeyValueObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueObserver.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				BFB8917B1E2E013400FA9129 /* MetalScope.h */,
+				BF46F0991EADDEDA00F5CB58 /* Deprecations+Removals.swift */,
 				BFDF48B81E8A52E200FC7A74 /* PanoramaView */,
 				BFAB12FD1E35B82D00A1642C /* StereoView */,
 				BFB891921E2E04EB00FA9129 /* OrientationNode */,
@@ -320,6 +323,7 @@
 				BFAB130B1E35D1E900A1642C /* StereoParameters.swift in Sources */,
 				BFAB12FF1E35B94400A1642C /* StereoRenderer.swift in Sources */,
 				BF9B15B61E44B4B1004CC8CE /* KeyValueObserver.swift in Sources */,
+				BF46F09A1EADDEDA00F5CB58 /* Deprecations+Removals.swift in Sources */,
 				BFAB13091E35BE9800A1642C /* ScreenModel.swift in Sources */,
 				BFFE23891E409046006097A1 /* MediaFormat.swift in Sources */,
 				BFAB13031E35B9DA00A1642C /* ViewerModel.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ player.play()
 panoramaView.scene = ...
 ```
 
-`PanoramaView` rotates the point of view by device motions and user's pan gesture. To reset rotation, just call `resetCenter()`
+`PanoramaView` rotates the point of view by device motions and user's pan gesture. To reset rotation, just call `setNeedsResetRotation()`
 
 ```swift
 let panoramaView: PanoramaView = ...
@@ -53,7 +53,7 @@ let panoramaView: PanoramaView = ...
 // double tap to re-center the scene
 let recognizer = UITapGestureRecognizer(
   target: panoramaView,
-  action: #selector(PanoramaView.resetCenter))
+  action: #selector(PanoramaView.setNeedsResetRotation))
 recognizer.numberOfTapsRequired = 2
 
 panoramaView.addGestureRecognizer(recognizer)

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -1,0 +1,45 @@
+//
+//  Deprecations+Removals.swift
+//  MetalScope
+//
+//  Created by Jun Tanaka on 2017/04/24.
+//  Copyright © 2017 eje Inc. All rights reserved.
+//
+
+import SceneKit
+
+extension PanoramaView {
+    @available(*, deprecated, message: "Use `setNeedsResetRotation()` instead")
+    public func resetCenter() {
+        setNeedsResetRotation()
+    }
+}
+
+extension StereoView {
+    @available(*, deprecated, message: "Use `setNeedsResetRotation()` instead")
+    public func resetCenter() {
+        setNeedsResetRotation()
+    }
+
+    @available(*, unavailable, message: "Use `sceneRendererDelegate` instead")
+    public func sceneRendererDelegate(for eye: Eye) -> SCNSceneRendererDelegate? {
+        fatalError("Use sceneRendererDelegate property instead")
+    }
+
+    @available(*, unavailable, message: "Use `sceneRendererDelegate` instead")
+    public func setSceneRendererDelegate(_ delegate: SCNSceneRendererDelegate, for eye: Eye) {
+        fatalError("Use sceneRendererDelegate property instead")
+    }
+}
+
+extension OrientationNode {
+    @available(*, renamed: "OrientationNode.resetRotation")
+    public func resetCenter() {
+        resetRotation()
+    }
+
+    @available(*, renamed: "OrientationNode.resetRotation")
+    public func resetCenter(animated: Bool, completionHanlder: (() -> Void)? = nil) {
+        resetRotation(animated: animated, completionHanlder: completionHanlder)
+    }
+}

--- a/Sources/OrientationNode.swift
+++ b/Sources/OrientationNode.swift
@@ -53,7 +53,7 @@ public final class OrientationNode: SCNNode {
         interfaceOrientationNode.orientation = rotation.scnQuaternion
     }
 
-    public func resetCenter() {
+    public func resetRotation() {
         let r1 = Rotation(pointOfView.worldTransform).inverted()
         let r2 = Rotation(referenceRotationNode.worldTransform)
         let r3 = r1 * r2
@@ -62,7 +62,7 @@ public final class OrientationNode: SCNNode {
         userRotationNode.transform = SCNMatrix4Identity
     }
 
-    public func resetCenter(animated: Bool, completionHanlder: (() -> Void)? = nil) {
+    public func resetRotation(animated: Bool, completionHanlder: (() -> Void)? = nil) {
         SCNTransaction.lock()
         SCNTransaction.begin()
         SCNTransaction.animationDuration = 0.6
@@ -70,7 +70,7 @@ public final class OrientationNode: SCNNode {
         SCNTransaction.completionBlock = completionHanlder
         SCNTransaction.disableActions = !animated
 
-        resetCenter()
+        resetRotation()
 
         SCNTransaction.commit()
         SCNTransaction.unlock()

--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -63,6 +63,9 @@ public final class PanoramaView: UIView, MediaSceneLoader {
         return InterfaceOrientationUpdater(orientationNode: self.orientationNode)
     }()
 
+    fileprivate var needsResetRotation = false
+    fileprivate var needsResetRotationQueue = DispatchQueue(label: "com.eje-c.MetalScope.PanoramaView.needsResetRotationQueue")
+
     #if (arch(arm) || arch(arm64)) && os(iOS)
     public init(frame: CGRect, device: MTLDevice) {
         self.device = device
@@ -139,8 +142,10 @@ extension PanoramaView {
         interfaceOrientationUpdater.updateInterfaceOrientation(with: transitionCoordinator)
     }
 
-    public func resetCenter() {
-        orientationNode.resetCenter(animated: true)
+    public func setNeedsResetRotation() {
+        needsResetRotationQueue.async(flags: [.barrier]) { [weak self] in
+            self?.needsResetRotation = true
+        }
     }
 }
 
@@ -172,6 +177,15 @@ extension PanoramaView: SCNSceneRendererDelegate {
 
         SCNTransaction.commit()
         SCNTransaction.unlock()
+
+        let needsResetRotation: Bool = needsResetRotationQueue.sync(execute: {
+            let value = self.needsResetRotation
+            self.needsResetRotation = false
+            return value
+        })
+        if needsResetRotation {
+            orientationNode.resetRotation(animated: !disableActions)
+        }
 
         sceneRendererDelegate?.renderer?(renderer, updateAtTime: time)
     }


### PR DESCRIPTION
This change replace `resetCenter()` with `setNeedsResetRotation()` for `PanoramaView` and `StereoView`. For `OrientationNode`, it just renamed to `resetRotation()`.

Unlike `resetCenter()`, `setNeedsResetRotation()` delays actual rotation changes until the next scene rendering frame.

This request also combines deprecated/removed APIs into the single `Deprecations+Removals.swift` file.