### PR TITLE
Split `MediaSceneLoader` protocol

### DIFF
--- a/MetalScope.xcodeproj/project.pbxproj
+++ b/MetalScope.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF1452DF1E320BAC0042598E /* MediaSceneLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1452DE1E320BAC0042598E /* MediaSceneLoader.swift */; };
-		BF1452E11E320BEF0042598E /* MediaSceneLoader+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1452E01E320BEF0042598E /* MediaSceneLoader+Image.swift */; };
-		BF1452E31E320C210042598E /* MediaSceneLoader+Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1452E21E320C210042598E /* MediaSceneLoader+Video.swift */; };
+		BF1452DF1E320BAC0042598E /* SceneLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1452DE1E320BAC0042598E /* SceneLoadable.swift */; };
 		BF1453061E321CE30042598E /* CategoryBitMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1453051E321CE30042598E /* CategoryBitMask.swift */; };
 		BF46F09A1EADDEDA00F5CB58 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF46F0991EADDEDA00F5CB58 /* Deprecations+Removals.swift */; };
+		BF46F0A11EADE9C300F5CB58 /* ImageLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF46F0A01EADE9C300F5CB58 /* ImageLoadable.swift */; };
+		BF46F0A31EADEA4600F5CB58 /* VideoLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF46F0A21EADEA4600F5CB58 /* VideoLoadable.swift */; };
 		BF603F551E41B57600A28013 /* OrientationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF603F541E41B57600A28013 /* OrientationIndicator.swift */; };
 		BF9B15B41E44B47F004CC8CE /* RenderLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9B15B31E44B47F004CC8CE /* RenderLoop.swift */; };
 		BF9B15B61E44B4B1004CC8CE /* KeyValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9B15B51E44B4B1004CC8CE /* KeyValueObserver.swift */; };
@@ -47,11 +47,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		BF1452DE1E320BAC0042598E /* MediaSceneLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MediaSceneLoader.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		BF1452E01E320BEF0042598E /* MediaSceneLoader+Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "MediaSceneLoader+Image.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		BF1452E21E320C210042598E /* MediaSceneLoader+Video.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "MediaSceneLoader+Video.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		BF1452DE1E320BAC0042598E /* SceneLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SceneLoadable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BF1453051E321CE30042598E /* CategoryBitMask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = CategoryBitMask.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		BF46F0991EADDEDA00F5CB58 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = "<group>"; };
+		BF46F0A01EADE9C300F5CB58 /* ImageLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageLoadable.swift; sourceTree = "<group>"; };
+		BF46F0A21EADEA4600F5CB58 /* VideoLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoLoadable.swift; sourceTree = "<group>"; };
 		BF603F541E41B57600A28013 /* OrientationIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrientationIndicator.swift; sourceTree = "<group>"; };
 		BF9B15B31E44B47F004CC8CE /* RenderLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderLoop.swift; sourceTree = "<group>"; };
 		BF9B15B51E44B4B1004CC8CE /* KeyValueObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueObserver.swift; sourceTree = "<group>"; };
@@ -199,9 +199,9 @@
 			isa = PBXGroup;
 			children = (
 				BFFE23881E409046006097A1 /* MediaFormat.swift */,
-				BF1452DE1E320BAC0042598E /* MediaSceneLoader.swift */,
-				BF1452E01E320BEF0042598E /* MediaSceneLoader+Image.swift */,
-				BF1452E21E320C210042598E /* MediaSceneLoader+Video.swift */,
+				BF1452DE1E320BAC0042598E /* SceneLoadable.swift */,
+				BF46F0A01EADE9C300F5CB58 /* ImageLoadable.swift */,
+				BF46F0A21EADEA4600F5CB58 /* VideoLoadable.swift */,
 				BFB8920A1E2F364B00FA9129 /* SphericalMediaScene.swift */,
 				BFA89A7D1E3108D0005A3529 /* ImageScene.swift */,
 				BFA89A791E310401005A3529 /* VideoScene.swift */,
@@ -306,19 +306,20 @@
 				BFB8918E1E2E039800FA9129 /* PlayerItemRenderer.swift in Sources */,
 				BFB891A21E2E08FC00FA9129 /* DeviceOrientationProvider.swift in Sources */,
 				BFA89A7E1E3108D0005A3529 /* ImageScene.swift in Sources */,
+				BF46F0A11EADE9C300F5CB58 /* ImageLoadable.swift in Sources */,
 				BF9B15B41E44B47F004CC8CE /* RenderLoop.swift in Sources */,
 				BFB891A61E2E109A00FA9129 /* Rotation+CoreMotion.swift in Sources */,
 				BFB892301E2F761600FA9129 /* PanoramaView+PanGesture.swift in Sources */,
 				BFAB13111E35EE0D00A1642C /* StereoScene.swift in Sources */,
 				BF1453061E321CE30042598E /* CategoryBitMask.swift in Sources */,
 				BFB891A41E2E090A00FA9129 /* Rotation.swift in Sources */,
+				BF46F0A31EADEA4600F5CB58 /* VideoLoadable.swift in Sources */,
 				BFFE23841E407DDD006097A1 /* InterfaceOrientationUpdater.swift in Sources */,
 				BFAB13131E361B3700A1642C /* StereoViewController.swift in Sources */,
 				BFB892691E30DCEA00FA9129 /* OrientationNode.swift in Sources */,
 				BFAB13051E35B9EB00A1642C /* ViewerParameters.swift in Sources */,
 				BFAB13071E35BE0C00A1642C /* ScreenParameters.swift in Sources */,
-				BF1452DF1E320BAC0042598E /* MediaSceneLoader.swift in Sources */,
-				BF1452E11E320BEF0042598E /* MediaSceneLoader+Image.swift in Sources */,
+				BF1452DF1E320BAC0042598E /* SceneLoadable.swift in Sources */,
 				BFB891B71E2E2A9900FA9129 /* InterfaceOrientationProvider.swift in Sources */,
 				BFAB130B1E35D1E900A1642C /* StereoParameters.swift in Sources */,
 				BFAB12FF1E35B94400A1642C /* StereoRenderer.swift in Sources */,
@@ -334,7 +335,6 @@
 				BFB8919F1E2E083000FA9129 /* PanoramaView.swift in Sources */,
 				BFB891A81E2E10CA00FA9129 /* Rotation+SceneKit.swift in Sources */,
 				BF603F551E41B57600A28013 /* OrientationIndicator.swift in Sources */,
-				BF1452E31E320C210042598E /* MediaSceneLoader+Video.swift in Sources */,
 				BFB8920B1E2F364B00FA9129 /* SphericalMediaScene.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -43,3 +43,6 @@ extension OrientationNode {
         resetRotation(animated: animated, completionHanlder: completionHanlder)
     }
 }
+
+@available(*, unavailable, message: "This protocol has been removed. Use `SceneLoadable`, `ImageLoadable` and `VideoLoadable` instead")
+public protocol MediaSceneLoader: class {}

--- a/Sources/ImageLoadable.swift
+++ b/Sources/ImageLoadable.swift
@@ -1,14 +1,19 @@
 //
-//  MediaSceneLoader+Image.swift
+//  ImageLoadable.swift
 //  MetalScope
 //
-//  Created by Jun Tanaka on 2017/01/20.
+//  Created by Jun Tanaka on 2017/04/24.
 //  Copyright © 2017 eje Inc. All rights reserved.
 //
 
 import SceneKit
+import UIKit
 
-extension MediaSceneLoader {
+public protocol ImageLoadable: class {
+    func load(_ image: UIImage, format: MediaFormat)
+}
+
+extension ImageLoadable where Self: SceneLoadable {
     public func load(_ image: UIImage, format: MediaFormat) {
         let scene: ImageScene
 

--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SceneKit
 
-public final class PanoramaView: UIView, MediaSceneLoader {
+public final class PanoramaView: UIView, SceneLoadable {
     #if (arch(arm) || arch(arm64)) && os(iOS)
     public let device: MTLDevice
     #endif
@@ -102,6 +102,12 @@ public final class PanoramaView: UIView, MediaSceneLoader {
         }
     }
 }
+
+extension PanoramaView: ImageLoadable {}
+
+#if (arch(arm) || arch(arm64)) && os(iOS)
+extension PanoramaView: VideoLoadable {}
+#endif
 
 extension PanoramaView {
     public var sceneRenderer: SCNSceneRenderer {

--- a/Sources/SceneLoadable.swift
+++ b/Sources/SceneLoadable.swift
@@ -1,5 +1,5 @@
 //
-//  MediaSceneLoader.swift
+//  SceneLoadable.swift
 //  MetalScope
 //
 //  Created by Jun Tanaka on 2017/01/20.
@@ -8,10 +8,6 @@
 
 import SceneKit
 
-public protocol MediaSceneLoader: class {
-    #if (arch(arm) || arch(arm64)) && os(iOS)
-    var device: MTLDevice { get }
-    #endif
-
+public protocol SceneLoadable: class {
     var scene: SCNScene? { get set }
 }

--- a/Sources/StereoView.swift
+++ b/Sources/StereoView.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SceneKit
 
-public final class StereoView: UIView, MediaSceneLoader {
+public final class StereoView: UIView, SceneLoadable {
     #if (arch(arm) || arch(arm64)) && os(iOS)
     public let stereoTexture: MTLTexture
 
@@ -174,6 +174,12 @@ public final class StereoView: UIView, MediaSceneLoader {
         scnView.frame = bounds
     }
 }
+
+extension StereoView: ImageLoadable {}
+
+#if (arch(arm) || arch(arm64)) && os(iOS)
+extension StereoView: VideoLoadable {}
+#endif
 
 extension StereoView {
     public var isPlaying: Bool {

--- a/Sources/StereoViewController.swift
+++ b/Sources/StereoViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import SceneKit
 
-open class StereoViewController: UIViewController, MediaSceneLoader {
+open class StereoViewController: UIViewController, SceneLoadable {
     #if (arch(arm) || arch(arm64)) && os(iOS)
     open let device: MTLDevice
     #endif
@@ -227,3 +227,9 @@ open class StereoViewController: UIViewController, MediaSceneLoader {
         }
     }
 }
+
+extension StereoViewController: ImageLoadable {}
+
+#if (arch(arm) || arch(arm64)) && os(iOS)
+extension StereoViewController: VideoLoadable {}
+#endif

--- a/Sources/VideoLoadable.swift
+++ b/Sources/VideoLoadable.swift
@@ -1,8 +1,8 @@
 //
-//  MediaSceneLoader+Video.swift
+//  VideoLoadable.swift
 //  MetalScope
 //
-//  Created by Jun Tanaka on 2017/01/20.
+//  Created by Jun Tanaka on 2017/04/24.
 //  Copyright © 2017 eje Inc. All rights reserved.
 //
 
@@ -11,7 +11,13 @@
 import SceneKit
 import AVFoundation
 
-extension MediaSceneLoader {
+public protocol VideoLoadable: class {
+    var device: MTLDevice { get }
+
+    func load(_ player: AVPlayer, format: MediaFormat)
+}
+
+extension VideoLoadable where Self: SceneLoadable {
     public func load(_ player: AVPlayer, format: MediaFormat) {
         let scene: VideoScene
 


### PR DESCRIPTION
This change splits `MediaSceneLoader` protocol into `SceneLoadable`, `ImageLoadable` and `VideoLoadable` protocols. `PanoramaView`, `StereoView` and `StereoViewController` are now conform them instead of `MediaSceneLoader`.

`ImageLoadable` and `VideoLoadable` have `load()` method in its protocol definition (not in protocol extension), so now you can override them.