### PR TITLE
`setNeedsResetRotation` is not animated as default

### DIFF
--- a/Examples/MonoImage/Sources/ViewController.swift
+++ b/Examples/MonoImage/Sources/ViewController.swift
@@ -26,7 +26,7 @@ final class ViewController: UIViewController {
         #else
         let panoramaView = PanoramaView(frame: view.bounds) // iOS Simulator
         #endif
-        panoramaView.setNeedsResetRotation(animated: false)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 
@@ -40,7 +40,7 @@ final class ViewController: UIViewController {
         NSLayoutConstraint.activate(constraints)
 
         // double tap to reset rotation
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation(_:)))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/MonoVideo/Sources/ViewController.swift
+++ b/Examples/MonoVideo/Sources/ViewController.swift
@@ -33,7 +33,7 @@ final class ViewController: UIViewController {
 
     private func loadPanoramaView() {
         let panoramaView = PanoramaView(frame: view.bounds, device: device)
-        panoramaView.setNeedsResetRotation(animated: false)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 
@@ -47,7 +47,7 @@ final class ViewController: UIViewController {
         NSLayoutConstraint.activate(constraints)
 
         // double tap to reset rotation
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation(_:)))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/StereoImage/Sources/ViewController.swift
+++ b/Examples/StereoImage/Sources/ViewController.swift
@@ -22,7 +22,7 @@ final class ViewController: UIViewController {
 
     private func loadPanoramaView() {
         let panoramaView = PanoramaView(frame: view.bounds, device: device)
-        panoramaView.setNeedsResetRotation(animated: false)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 
@@ -36,7 +36,7 @@ final class ViewController: UIViewController {
         NSLayoutConstraint.activate(constraints)
 
         // double tap to reset rotation
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation(_:)))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/Examples/StereoVideo/Sources/ViewController.swift
+++ b/Examples/StereoVideo/Sources/ViewController.swift
@@ -33,7 +33,7 @@ final class ViewController: UIViewController {
 
     private func loadPanoramaView() {
         let panoramaView = PanoramaView(frame: view.bounds, device: device)
-        panoramaView.setNeedsResetRotation(animated: false)
+        panoramaView.setNeedsResetRotation()
         panoramaView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(panoramaView)
 
@@ -47,7 +47,7 @@ final class ViewController: UIViewController {
         NSLayoutConstraint.activate(constraints)
 
         // double tap to reset rotation
-        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation))
+        let doubleTapGestureRecognizer = UITapGestureRecognizer(target: panoramaView, action: #selector(PanoramaView.setNeedsResetRotation(_:)))
         doubleTapGestureRecognizer.numberOfTapsRequired = 2
         panoramaView.addGestureRecognizer(doubleTapGestureRecognizer)
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let panoramaView: PanoramaView = ...
 // double tap to re-center the scene
 let recognizer = UITapGestureRecognizer(
   target: panoramaView,
-  action: #selector(PanoramaView.setNeedsResetRotation))
+  action: #selector(PanoramaView.setNeedsResetRotation(_:)))
 recognizer.numberOfTapsRequired = 2
 
 panoramaView.addGestureRecognizer(recognizer)

--- a/Sources/Deprecations+Removals.swift
+++ b/Sources/Deprecations+Removals.swift
@@ -9,14 +9,14 @@
 import SceneKit
 
 extension PanoramaView {
-    @available(*, deprecated, message: "Use `setNeedsResetRotation()` instead")
+    @available(*, deprecated, message: "Use `setNeedsResetRotation` instead")
     public func resetCenter() {
-        setNeedsResetRotation()
+        setNeedsResetRotation(animated: true)
     }
 }
 
 extension StereoView {
-    @available(*, deprecated, message: "Use `setNeedsResetRotation()` instead")
+    @available(*, deprecated, message: "Use `setNeedsResetRotation` instead")
     public func resetCenter() {
         setNeedsResetRotation()
     }

--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -149,6 +149,10 @@ extension PanoramaView {
         panGestureManager.stopAnimations()
         orientationNode.setNeedsResetRotation(animated: animated)
     }
+
+    public func setNeedsResetRotation(_ sender: Any?) {
+        setNeedsResetRotation(animated: true)
+    }
 }
 
 extension PanoramaView: OrientationIndicatorDataSource {

--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -145,9 +145,8 @@ extension PanoramaView {
         interfaceOrientationUpdater.updateInterfaceOrientation(with: transitionCoordinator)
     }
 
-    public func setNeedsResetRotation(animated: Bool = true) {
+    public func setNeedsResetRotation(animated: Bool = false) {
         panGestureManager.stopAnimations()
-
         orientationNode.setNeedsResetRotation(animated: animated)
     }
 }


### PR DESCRIPTION
For clarity, `PanoramaView.setNeedsResetRotation(animated:)` should not animated as default.

Instead, add new `PanoramaView.setNeedsResetRotation(_:)` method for Cocoa actions.
```swift
// old
resetButton.addTarget(panoramaView, 
                      action: #selector(PanoramaView.setNeedsResetRotation), 
                      for: .touchUpInside)

// new
resetButton.addTarget(panoramaView, 
                      action: #selector(PanoramaView.setNeedsResetRotation(_:)), 
                      for: .touchUpInside)
```