### PR TITLE
Extract default implementations for `Loadable` protocols

### DIFF
--- a/Sources/ImageLoadable.swift
+++ b/Sources/ImageLoadable.swift
@@ -9,7 +9,7 @@
 import SceneKit
 import UIKit
 
-public protocol ImageLoadable: class {
+public protocol ImageLoadable {
     func load(_ image: UIImage, format: MediaFormat)
 }
 
@@ -27,5 +27,6 @@ extension ImageLoadable where Self: SceneLoadable {
         scene.image = image
 
         self.scene = (scene as? SCNScene)
+        target.scene = (scene as? SCNScene)
     }
 }

--- a/Sources/ImageLoadable.swift
+++ b/Sources/ImageLoadable.swift
@@ -15,6 +15,18 @@ public protocol ImageLoadable {
 
 extension ImageLoadable where Self: SceneLoadable {
     public func load(_ image: UIImage, format: MediaFormat) {
+        ImageSceneLoader(target: self).load(image, format: format)
+    }
+}
+
+public struct ImageSceneLoader<Target: SceneLoadable>: ImageLoadable {
+    public let target: Target
+
+    public init(target: Target) {
+        self.target = target
+    }
+
+    public func load(_ image: UIImage, format: MediaFormat) {
         let scene: ImageScene
 
         switch format {
@@ -26,7 +38,6 @@ extension ImageLoadable where Self: SceneLoadable {
 
         scene.image = image
 
-        self.scene = (scene as? SCNScene)
         target.scene = (scene as? SCNScene)
     }
 }

--- a/Sources/VideoLoadable.swift
+++ b/Sources/VideoLoadable.swift
@@ -11,7 +11,7 @@
 import SceneKit
 import AVFoundation
 
-public protocol VideoLoadable: class {
+public protocol VideoLoadable {
     var device: MTLDevice { get }
 
     func load(_ player: AVPlayer, format: MediaFormat)

--- a/Sources/VideoLoadable.swift
+++ b/Sources/VideoLoadable.swift
@@ -19,6 +19,20 @@ public protocol VideoLoadable {
 
 extension VideoLoadable where Self: SceneLoadable {
     public func load(_ player: AVPlayer, format: MediaFormat) {
+        VideoSceneLoader(target: self).load(player, format: format)
+    }
+}
+
+public struct VideoSceneLoader<Target: SceneLoadable>: VideoLoadable {
+    public let target: Target
+    public let device: MTLDevice
+
+    public init(target: Target, device: MTLDevice) {
+        self.target = target
+        self.device = device
+    }
+
+    public func load(_ player: AVPlayer, format: MediaFormat) {
         let scene: VideoScene
 
         switch format {
@@ -30,7 +44,13 @@ extension VideoLoadable where Self: SceneLoadable {
 
         scene.player = player
 
-        self.scene = (scene as? SCNScene)
+        target.scene = (scene as? SCNScene)
+    }
+}
+
+extension VideoSceneLoader where Target: VideoLoadable {
+    public init(target: Target) {
+        self.init(target: target, device: target.device)
     }
 }
 


### PR DESCRIPTION
Extract the `load` methods (originally implemented as a protocol extension for `[Image|Video]Loadable`) as new `[Image|Video]SceneLoader` structs.

```swift
// old
extension ImageLoadable where Self: SceneLoadable {
    public func load(_ image: UIImage, format: MediaFormat) {
        // create scene...

        self.scene = scene
    }
}

// new
extension ImageLoadable where Self: SceneLoadable {
    public func load(_ image: UIImage, format: MediaFormat) {
        ImageSceneLoader(target: self).load(image, format: format)
    }
}

public struct ImageSceneLoader<Target: SceneLoadable>: ImageLoadable {
    public let target: Target

    public init(target: Target) {
        self.target = target
    }

    public func load(_ image: UIImage, format: MediaFormat) {
        // create scene...

        target.scene = scene
    }
}
```