### PR TITLE
Simplify scene loaders

### DIFF
--- a/Sources/ImageLoadable.swift
+++ b/Sources/ImageLoadable.swift
@@ -15,18 +15,14 @@ public protocol ImageLoadable {
 
 extension ImageLoadable where Self: SceneLoadable {
     public func load(_ image: UIImage, format: MediaFormat) {
-        ImageSceneLoader(target: self).load(image, format: format)
+        scene = ImageSceneLoader().load(image, format: format)
     }
 }
 
-public struct ImageSceneLoader<Target: SceneLoadable>: ImageLoadable {
-    public let target: Target
+public struct ImageSceneLoader {
+    public init() {}
 
-    public init(target: Target) {
-        self.target = target
-    }
-
-    public func load(_ image: UIImage, format: MediaFormat) {
+    public func load(_ image: UIImage, format: MediaFormat) -> SCNScene {
         let scene: ImageScene
 
         switch format {
@@ -38,6 +34,6 @@ public struct ImageSceneLoader<Target: SceneLoadable>: ImageLoadable {
 
         scene.image = image
 
-        target.scene = (scene as? SCNScene)
+        return scene as! SCNScene
     }
 }

--- a/Sources/VideoLoadable.swift
+++ b/Sources/VideoLoadable.swift
@@ -19,20 +19,18 @@ public protocol VideoLoadable {
 
 extension VideoLoadable where Self: SceneLoadable {
     public func load(_ player: AVPlayer, format: MediaFormat) {
-        VideoSceneLoader(target: self).load(player, format: format)
+        scene = VideoSceneLoader(device: device).load(player, format: format)
     }
 }
 
-public struct VideoSceneLoader<Target: SceneLoadable>: VideoLoadable {
-    public let target: Target
+public struct VideoSceneLoader {
     public let device: MTLDevice
 
-    public init(target: Target, device: MTLDevice) {
-        self.target = target
+    public init(device: MTLDevice) {
         self.device = device
     }
 
-    public func load(_ player: AVPlayer, format: MediaFormat) {
+    public func load(_ player: AVPlayer, format: MediaFormat) -> SCNScene {
         let scene: VideoScene
 
         switch format {
@@ -44,13 +42,7 @@ public struct VideoSceneLoader<Target: SceneLoadable>: VideoLoadable {
 
         scene.player = player
 
-        target.scene = (scene as? SCNScene)
-    }
-}
-
-extension VideoSceneLoader where Target: VideoLoadable {
-    public init(target: Target) {
-        self.init(target: target, device: target.device)
+       return scene as! SCNScene
     }
 }
 


### PR DESCRIPTION
Before:
```swift
extension ImageLoadable where Self: SceneLoadable {
    public func load(_ image: UIImage, format: MediaFormat) {
        ImageSceneLoader(target: self).load(image, format: format)
    }
}

public struct ImageSceneLoader<Target: SceneLoadable>: ImageLoadable {
    public let target: Target

    public init(target: Target) {
        self.target = target
    }

    public func load(_ image: UIImage, format: MediaFormat) {
        // create scene...

        target.scene = scene
    }
}
```

After:
```swift
extension ImageLoadable where Self: SceneLoadable {
    public func load(_ image: UIImage, format: MediaFormat) {
        scene = ImageSceneLoader().load(image, format: format)
    }
}

public struct ImageSceneLoader {
    public init() {}

    public func load(_ image: UIImage, format: MediaFormat) -> SCNScene {
        // create scene...

        return scene
    }
}
```