### PR TITLE
Fix opaque alpha blending on MTLTexture

### DIFF
--- a/Sources/SphericalMediaScene.swift
+++ b/Sources/SphericalMediaScene.swift
@@ -27,6 +27,7 @@ public final class MediaSphereNode: SCNNode {
         geometry = sphere
 
         scale = SCNVector3(x: 1, y: 1, z: -1)
+        renderingOrder = .max
     }
 
     public required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
This change fix wrong alpha blending inside `MediaSphereNode` which has `MTLTexture` as its material contents.