### PR TITLE
Set `OrientationNode.pointOfView.camera.zNear` to `0.3` as default

### DIFF
--- a/Sources/OrientationNode.swift
+++ b/Sources/OrientationNode.swift
@@ -32,6 +32,7 @@ public final class OrientationNode: SCNNode {
         let camera = SCNCamera()
         camera.xFov = 60
         camera.yFov = 60
+        camera.zNear = 0.3
         pointOfView.camera = camera
     }
 


### PR DESCRIPTION
Change default value of `OrientationNode.pointOfView.camera.zNear` from `1.0` to `0.3`