### PR TITLE
Detach `OrientationNode` at `deinit` correctly

### DIFF
--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -81,7 +81,7 @@ public final class PanoramaView: UIView, SceneLoadable {
     }
 
     deinit {
-        scene = nil
+        orientationNode.removeFromParentNode()
     }
 
     public override func layoutSubviews() {

--- a/Sources/StereoView.swift
+++ b/Sources/StereoView.swift
@@ -162,7 +162,7 @@ public final class StereoView: UIView, SceneLoadable {
     }
 
     deinit {
-        scene = nil
+        orientationNode.removeFromParentNode()
     }
 
     public override func layoutSubviews() {


### PR DESCRIPTION
`didSet` is not called in `deinit`