### PR TITLE
Support iOS 11

### DIFF
--- a/Sources/InterfaceOrientationProvider.swift
+++ b/Sources/InterfaceOrientationProvider.swift
@@ -9,36 +9,23 @@
 import UIKit
 
 public protocol InterfaceOrientationProvider {
-    func interfaceOrientation(atTime time: TimeInterval) -> Rotation?
+    func interfaceOrientation(atTime time: TimeInterval) -> UIInterfaceOrientation
 }
 
 extension UIInterfaceOrientation: InterfaceOrientationProvider {
-    public func interfaceOrientation(atTime time: TimeInterval) -> Rotation? {
-        var rotation = Rotation()
-
-        switch self {
-        case .portraitUpsideDown:
-            rotation.rotate(byZ: .pi)
-        case .landscapeLeft:
-            rotation.rotate(byZ: .pi / 2)
-        case .landscapeRight:
-            rotation.rotate(byZ: .pi / -2)
-        default:
-            break
-        }
-
-        return rotation
+    public func interfaceOrientation(atTime time: TimeInterval) -> UIInterfaceOrientation {
+        return self
     }
 }
 
 extension UIApplication: InterfaceOrientationProvider {
-    public func interfaceOrientation(atTime time: TimeInterval) -> Rotation? {
+    public func interfaceOrientation(atTime time: TimeInterval) -> UIInterfaceOrientation {
         return statusBarOrientation.interfaceOrientation(atTime: time)
     }
 }
 
 internal final class DefaultInterfaceOrientationProvider: InterfaceOrientationProvider {
-    func interfaceOrientation(atTime time: TimeInterval) -> Rotation? {
+    func interfaceOrientation(atTime time: TimeInterval) -> UIInterfaceOrientation {
         return UIApplication.shared.interfaceOrientation(atTime: time)
     }
 }

--- a/Sources/OrientationIndicator.swift
+++ b/Sources/OrientationIndicator.swift
@@ -116,19 +116,29 @@ public final class OrientationIndicatorLayer: CALayer, OrientationIndicator {
         let viewportRatio = Double(dataSource.viewportSize.width / dataSource.viewportSize.height)
 
         let fovInDegree: Double
-        if camera.xFov != 0 && camera.yFov != 0 {
-            let fovRatio = camera.xFov / camera.yFov
-            if fovRatio > viewportRatio {
-                fovInDegree = camera.xFov
-            } else {
-                fovInDegree = camera.yFov * viewportRatio
+
+        if #available(iOS 11, *) {
+            switch camera.projectionDirection {
+            case .horizontal:
+                fovInDegree = Double(camera.fieldOfView)
+            case .vertical:
+                fovInDegree = Double(camera.fieldOfView) * viewportRatio
             }
-        } else if camera.xFov != 0 {
-            fovInDegree = camera.xFov
-        } else if camera.yFov != 0 {
-            fovInDegree = camera.yFov * viewportRatio
         } else {
-            fovInDegree = 60 * viewportRatio
+            if camera.xFov != 0 && camera.yFov != 0 {
+                let fovRatio = camera.xFov / camera.yFov
+                if fovRatio > viewportRatio {
+                    fovInDegree = camera.xFov
+                } else {
+                    fovInDegree = camera.yFov * viewportRatio
+                }
+            } else if camera.xFov != 0 {
+                fovInDegree = camera.xFov
+            } else if camera.yFov != 0 {
+                fovInDegree = camera.yFov * viewportRatio
+            } else {
+                fovInDegree = 60 * viewportRatio
+            }
         }
 
         fov = Float(fovInDegree) / 180 * .pi

--- a/Sources/OrientationNode.swift
+++ b/Sources/OrientationNode.swift
@@ -16,6 +16,12 @@ public final class OrientationNode: SCNNode {
 
     public let pointOfView = SCNNode()
 
+    public var fieldOfView: CGFloat = 60 {
+        didSet {
+            self.updateCamera()
+        }
+    }
+
     public var deviceOrientationProvider: DeviceOrientationProvider? = DefaultDeviceOrientationProvider()
 
     public var interfaceOrientationProvider: InterfaceOrientationProvider? = DefaultInterfaceOrientationProvider()
@@ -30,10 +36,10 @@ public final class OrientationNode: SCNNode {
         interfaceOrientationNode.addChildNode(pointOfView)
 
         let camera = SCNCamera()
-        camera.xFov = 60
-        camera.yFov = 60
         camera.zNear = 0.3
         pointOfView.camera = camera
+
+        self.updateCamera()
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -48,10 +54,37 @@ public final class OrientationNode: SCNNode {
     }
 
     public func updateInterfaceOrientation(atTime time: TimeInterval = ProcessInfo.processInfo.systemUptime) {
-        guard let rotation = interfaceOrientationProvider?.interfaceOrientation(atTime: time) else {
+        guard let interfaceOrientation = interfaceOrientationProvider?.interfaceOrientation(atTime: time) else {
             return
         }
+
+        var rotation = Rotation()
+
+        switch interfaceOrientation {
+        case .portraitUpsideDown:
+            rotation.rotate(byZ: .pi)
+        case .landscapeLeft:
+            rotation.rotate(byZ: .pi / 2)
+        case .landscapeRight:
+            rotation.rotate(byZ: .pi / -2)
+        default:
+            break
+        }
+
         interfaceOrientationNode.orientation = rotation.scnQuaternion
+
+        if #available(iOS 11, *) {
+            let cameraProjectionDirection: SCNCameraProjectionDirection
+
+            switch interfaceOrientation {
+            case .landscapeLeft, .landscapeRight:
+                cameraProjectionDirection = .vertical
+            default:
+                cameraProjectionDirection = .horizontal
+            }
+
+            pointOfView.camera?.projectionDirection = cameraProjectionDirection
+        }
     }
 
     public func resetRotation() {
@@ -85,5 +118,18 @@ public final class OrientationNode: SCNNode {
             (node as! OrientationNode).resetRotation(animated: animated)
         }
         runAction(action, forKey: "setNeedsResetRotation")
+    }
+
+    private func updateCamera() {
+        guard let camera = self.pointOfView.camera else {
+            return
+        }
+
+        if #available(iOS 11, *) {
+            camera.fieldOfView = fieldOfView
+        } else {
+            camera.xFov = Double(fieldOfView)
+            camera.yFov = Double(fieldOfView)
+        }
     }
 }

--- a/Sources/StereoRenderer.swift
+++ b/Sources/StereoRenderer.swift
@@ -49,6 +49,7 @@ internal final class StereoRenderer {
             height: outputTexture.height,
             mipmapped: true
         )
+        eyeTextureDescriptor.usage = .renderTarget
 
         eyeRenderingConfigurations = [
             .left: EyeRenderingConfiguration(texture: device.makeTexture(descriptor: eyeTextureDescriptor)),

--- a/Sources/StereoScene.swift
+++ b/Sources/StereoScene.swift
@@ -35,6 +35,7 @@ internal final class StereoScene: SCNScene {
 
         let node = SCNNode()
         node.camera = camera
+        node.position = SCNVector3(0, 0, 0.01)
         self.rootNode.addChildNode(node)
         return node
     }()


### PR DESCRIPTION
Fix some issues on iOS 11 #28

- Specify missing `MTLTextureUsageRenderTarget` for eye textures
- Adjust `pointOfView` in `StereoScene` to fix black screen issue on iOS 11
- Handle `SCNCameraProjectionDirection` in `OrientationNode`
- Handle `SCNCameraProjectionDirection` in `OrientationIndicator`