### PR TITLE
Add isDeviceMotionEnabled & isPanGestureEnabled

### DIFF
--- a/Sources/PanoramaPanGestureManager.swift
+++ b/Sources/PanoramaPanGestureManager.swift
@@ -10,18 +10,25 @@ import UIKit
 import UIKit.UIGestureRecognizerSubclass
 import SceneKit
 
-final class PanoramaPanGestureManager {
-    let rotationNode: SCNNode
+public final class PanoramaPanGestureManager {
+    public var isEnabled: Bool {
+        get {
+            return self.gestureRecognizer.isEnabled
+        }
+        set {
+            self.gestureRecognizer.isEnabled = newValue
+        }
+    }
 
-    var allowsVerticalRotation = true
-    var minimumVerticalRotationAngle: Float?
-    var maximumVerticalRotationAngle: Float?
+    public var allowsVerticalRotation = true
+    public var minimumVerticalRotationAngle: Float?
+    public var maximumVerticalRotationAngle: Float?
 
-    var allowsHorizontalRotation = true
-    var minimumHorizontalRotationAngle: Float?
-    var maximumHorizontalRotationAngle: Float?
+    public var allowsHorizontalRotation = true
+    public var minimumHorizontalRotationAngle: Float?
+    public var maximumHorizontalRotationAngle: Float?
 
-    lazy var gestureRecognizer: UIPanGestureRecognizer = {
+    internal lazy var gestureRecognizer: UIPanGestureRecognizer = {
         let recognizer = AdvancedPanGestureRecognizer()
         recognizer.addTarget(self, action: #selector(handlePanGesture(_:)))
         recognizer.earlyTouchEventHandler = { [weak self] in
@@ -33,11 +40,13 @@ final class PanoramaPanGestureManager {
 
     private var referenceAngles: SCNVector3?
 
-    init(rotationNode: SCNNode) {
+    private let rotationNode: SCNNode
+
+    internal init(rotationNode: SCNNode) {
         self.rotationNode = rotationNode
     }
 
-    @objc func handlePanGesture(_ sender: UIPanGestureRecognizer) {
+    @objc fileprivate func handlePanGesture(_ sender: UIPanGestureRecognizer) {
         guard let view = sender.view else {
             return
         }

--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -48,6 +48,15 @@ public final class PanoramaView: UIView, SceneLoadable {
         }
     }
 
+    public var isPanGestureEnabled: Bool {
+        get {
+            return self.panGestureManager.isEnabled
+        }
+        set {
+            self.panGestureManager.isEnabled = newValue
+        }
+    }
+
     public lazy var panGestureManager: PanoramaPanGestureManager = {
         let manager = PanoramaPanGestureManager(rotationNode: self.orientationNode.userRotationNode)
         manager.minimumVerticalRotationAngle = -60 / 180 * .pi

--- a/Sources/PanoramaView.swift
+++ b/Sources/PanoramaView.swift
@@ -48,6 +48,13 @@ public final class PanoramaView: UIView, SceneLoadable {
         }
     }
 
+    public lazy var panGestureManager: PanoramaPanGestureManager = {
+        let manager = PanoramaPanGestureManager(rotationNode: self.orientationNode.userRotationNode)
+        manager.minimumVerticalRotationAngle = -60 / 180 * .pi
+        manager.maximumVerticalRotationAngle = 60 / 180 * .pi
+        return manager
+    }()
+
     public lazy var orientationNode: OrientationNode = {
         let node = OrientationNode()
         let mask = CategoryBitMask.all.subtracting(.rightEye)
@@ -71,13 +78,6 @@ public final class PanoramaView: UIView, SceneLoadable {
         view.isPlaying = true
         self.addSubview(view)
         return view
-    }()
-
-    fileprivate lazy var panGestureManager: PanoramaPanGestureManager = {
-        let manager = PanoramaPanGestureManager(rotationNode: self.orientationNode.userRotationNode)
-        manager.minimumVerticalRotationAngle = -60 / 180 * .pi
-        manager.maximumVerticalRotationAngle = 60 / 180 * .pi
-        return manager
     }()
 
     fileprivate lazy var interfaceOrientationUpdater: InterfaceOrientationUpdater = {


### PR DESCRIPTION
## Summary
Provides options to disable device motions and pan gestures in `PanoramaView`.

## Detail
Add following new properties to `PanoramaView`:

```swift
// PanoramaView.swift

public var isDeviceMotionEnabled: Bool { get set }

public var isPanGestureEnabled: Bool { get set }
```

Also make `PanoramaPanGestureManager` public to allow detailed settings of pan gesture. 

```swift
// PanoramaView.swift

public lazy var panGestureManager: PanoramaPanGestureManager { get set }
```